### PR TITLE
(fix):Added a function to deal with the target species not found in Model

### DIFF
--- a/pymars/drg.py
+++ b/pymars/drg.py
@@ -8,10 +8,10 @@ import networkx
 import numpy as np
 import h5py
 import cantera as ct
-
 import soln2ck
 import soln2cti
 import helper
+from  helper import target_error_check
 from simulation import Simulation
 from create_trimmed_model import trim
 from readin_initial_conditions import readin_conditions
@@ -100,6 +100,7 @@ def trim_drg(total_edge_data, solution_object, threshold_value, keeper_list, don
 
             # Search graph for max values to each species based on targets
            
+            target_error_check(graph,target_species)#check if target species is in model
             dic = graph_search(graph, target_species)
             # Add to max dictionary if it is new or greater than the value already there.
             for sp in dic:
@@ -171,7 +172,6 @@ def run_drg(solution_object, conditions_file, error_limit, target_species,
     """
     
     assert target_species, 'Need to specify at least one target species.'
-    target_error_check(solution_object.species(),target_species)
     # Singleton to hold whether any more species can be cut from the simulation.
     done = []
     done.append(False)
@@ -417,32 +417,6 @@ def get_rates_drg(sim_array, solution_object):
         total_edge_data[ic] = ic_edge_data
     return total_edge_data
 
-def target_error_check(solution, target_species):
-    """
-    check if target species are present in graph before attempting to remove them, 
-    if a target is absent from the graph the program will exit with error message
-
-    Parameters
-    ----------
-    nx_graph : obj
-        networkx graph object of solution
-    target_species : list
-        List of target species to search from
-
-    Returns
-    -------
-    void
-
-    """
-    targetInGraph=False;
-    for target in target_species:
-        targetInGraph=False;
-        for species in solution:
-            if species.name==target:
-                targetInGraph=True
-        if(not targetInGraph):
-            sys.exit('exiting with error target species ' + target + ' not found model')
-    return
 def graph_search(nx_graph, target_species):
     """
     Search nodal graph and generate list of species to remove

--- a/pymars/drg.py
+++ b/pymars/drg.py
@@ -99,6 +99,7 @@ def trim_drg(total_edge_data, solution_object, threshold_value, keeper_list, don
                     continue
 
             # Search graph for max values to each species based on targets
+           
             dic = graph_search(graph, target_species)
             # Add to max dictionary if it is new or greater than the value already there.
             for sp in dic:
@@ -170,7 +171,7 @@ def run_drg(solution_object, conditions_file, error_limit, target_species,
     """
     
     assert target_species, 'Need to specify at least one target species.'
-
+    target_error_check(solution_object.species(),target_species)
     # Singleton to hold whether any more species can be cut from the simulation.
     done = []
     done.append(False)
@@ -416,6 +417,32 @@ def get_rates_drg(sim_array, solution_object):
         total_edge_data[ic] = ic_edge_data
     return total_edge_data
 
+def target_error_check(solution, target_species):
+    """
+    check if target species are present in graph before attempting to remove them, 
+    if a target is absent from the graph the program will exit with error message
+
+    Parameters
+    ----------
+    nx_graph : obj
+        networkx graph object of solution
+    target_species : list
+        List of target species to search from
+
+    Returns
+    -------
+    void
+
+    """
+    targetInGraph=False;
+    for target in target_species:
+        targetInGraph=False;
+        for species in solution:
+            if species.name==target:
+                targetInGraph=True
+        if(not targetInGraph):
+            sys.exit('exiting with error target species ' + target + ' not found model')
+    return
 def graph_search(nx_graph, target_species):
     """
     Search nodal graph and generate list of species to remove

--- a/pymars/drgep.py
+++ b/pymars/drgep.py
@@ -4,6 +4,7 @@ import h5py
 import os, sys, argparse
 import cantera as ct
 import soln2ck
+from drg import target_error_check
 import soln2cti
 from readin_initial_conditions import readin_conditions
 from simulation import Simulation
@@ -170,7 +171,8 @@ def run_drgep(solution_object, conditions_file, error_limit, target_species, ret
 	# Set up variables
 	if len(target_species) == 0: # If the target species are not specified, puke and die.
 		print("Please specify a target species.")
-		exit()
+		exit()	
+	target_error_check(solution_object.species(),target_species)#check if target species is in model
 	done = [] # Singleton to hold wether or not any more species can be cut from the simulation.
 	done.append(False)
 	threshold = .1 # Starting threshold value

--- a/pymars/drgep.py
+++ b/pymars/drgep.py
@@ -4,7 +4,7 @@ import h5py
 import os, sys, argparse
 import cantera as ct
 import soln2ck
-from drg import target_error_check
+from helper import target_error_check
 import soln2cti
 from readin_initial_conditions import readin_conditions
 from simulation import Simulation
@@ -83,7 +83,11 @@ def make_dic_drgep(solution_object, total_edge_data, target_species):
                     print(edge)
                     continue
 
-            # Search the graph for overall interaction coefficents and add them to max_dic if they belong
+            
+
+# Search the graph for overall interaction coefficents and add them to max_dic if they belong
+
+            target_error_check(graph,target_species)
             dic = graph_search_drgep(graph, target_species) # Search graph for max values to each species based on targets
             for sp in dic: # Add to max dictionary if it is new or greater than the value already there.
                 if sp not in max_dic:
@@ -172,7 +176,6 @@ def run_drgep(solution_object, conditions_file, error_limit, target_species, ret
 	if len(target_species) == 0: # If the target species are not specified, puke and die.
 		print("Please specify a target species.")
 		exit()	
-	target_error_check(solution_object.species(),target_species)#check if target species is in model
 	done = [] # Singleton to hold wether or not any more species can be cut from the simulation.
 	done.append(False)
 	threshold = .1 # Starting threshold value

--- a/pymars/helper.py
+++ b/pymars/helper.py
@@ -1,3 +1,4 @@
+
 ##############
 # This function takes the conditions array and converts it into an array of simulation species_objects
 #
@@ -9,7 +10,7 @@
 
 from simulation import Simulation
 import numpy as np
-
+import sys
 def setup_simulations(conditions_array, model):
     sim_array = []
     i = 0
@@ -45,3 +46,26 @@ def simulate(sim_array):
 
         ignition_delay = np.array(tau) #Turn tau array into a numpy array
         return ignition_delay
+
+def target_error_check(graph, target_species):
+    """
+    check if target species are present in solution object before attempting to remove them, 
+    if a target is absent from the graph the program will exit with error message
+
+    Parameters
+    ----------
+    graph : obj
+        networkx graph object of solution
+    target_species : list
+        List of target species to search from
+
+    Returns
+    -------
+    void
+
+    """
+    for target in target_species:
+        if(target not in graph):
+            sys.exit('exiting with error target species ' + target + ' not found model')
+    return
+

--- a/pymars/pfa.py
+++ b/pymars/pfa.py
@@ -4,7 +4,6 @@ import h5py
 from collections import Counter
 import time as tm
 from drg import graph_search
-from drg import target_error_check
 import os, sys, argparse
 import cantera as ct
 import soln2ck
@@ -14,6 +13,7 @@ from create_trimmed_model import trim
 from numpy import genfromtxt
 from readin_initial_conditions import readin_conditions
 import helper
+from helper import target_error_check
 
 def trim_pfa(total_edge_data, solution_object, threshold_value, keeper_list, done, target_species, model_file):
 
@@ -84,6 +84,7 @@ def trim_pfa(total_edge_data, solution_object, threshold_value, keeper_list, don
                 except IndexError:
                     print(edge)
                     continue
+            target_error_check(graph,target_species)#check if target species is in model
             dic = graph_search(graph, target_species) # Search graph for max values to each species based on targets
             for sp in dic: # Add to max dictionary if it is new or greater than the value already there.
                 if sp not in safe:
@@ -149,7 +150,6 @@ def run_pfa(solution_object, conditions_file, error_limit, target_species, retai
 	if len(target_species) == 0: # If the target species are not specified, puke and die.
 		print("Please specify a target species.")
 		exit()
-	target_error_check(solution_object.species(),target_species)#check if target species is in model
 
 	done = [] # Singleton to hold wether or not any more species can be cut from the simulation.
 	done.append(False)

--- a/pymars/pfa.py
+++ b/pymars/pfa.py
@@ -4,6 +4,7 @@ import h5py
 from collections import Counter
 import time as tm
 from drg import graph_search
+from drg import target_error_check
 import os, sys, argparse
 import cantera as ct
 import soln2ck
@@ -83,7 +84,6 @@ def trim_pfa(total_edge_data, solution_object, threshold_value, keeper_list, don
                 except IndexError:
                     print(edge)
                     continue
-
             dic = graph_search(graph, target_species) # Search graph for max values to each species based on targets
             for sp in dic: # Add to max dictionary if it is new or greater than the value already there.
                 if sp not in safe:
@@ -149,6 +149,8 @@ def run_pfa(solution_object, conditions_file, error_limit, target_species, retai
 	if len(target_species) == 0: # If the target species are not specified, puke and die.
 		print("Please specify a target species.")
 		exit()
+	target_error_check(solution_object.species(),target_species)#check if target species is in model
+
 	done = [] # Singleton to hold wether or not any more species can be cut from the simulation.
 	done.append(False)
 	threshold = .1 # Starting threshold value


### PR DESCRIPTION
Went Through 3 iterations of this function think I landed on a pretty good one. Let me know if you want fixes Phill. In short the code calls a function defined in drg.py and imported into PFA and DRGEP at the very beginning of the run_method function that iterates through the Target species and the solution's_object.species().names and check if they are ever equal if so it sets a flag if  the flag is not set at the end of the iteration through solution's_object.species().names the program exits with an error and clear message of what went wrong. 

Ex: 

user runs: 
python __main__.py -m ../example_files/gri30.cti --conditions ../example_files/example_input_file.txt -e 5 --method DRGEP --targets CH4 O2 sk8 --retained_species CH4 O2 N2 CO2 H2O

gets output:
exiting with error target species sk8 not found model